### PR TITLE
Graceful handling of 404 errors when publishing a new plugin

### DIFF
--- a/rest/src/main/kotlin/org/jetbrains/intellij/pluginRepository/exceptions/UploadFailedException.kt
+++ b/rest/src/main/kotlin/org/jetbrains/intellij/pluginRepository/exceptions/UploadFailedException.kt
@@ -1,3 +1,3 @@
 package org.jetbrains.intellij.pluginRepository.exceptions
 
-class UploadFailedException(message: String?) : Exception(message)
+class UploadFailedException(message: String?, cause: Throwable?) : Exception(message, cause)


### PR DESCRIPTION
+ pass the cause to let clients handle the exception by themselves

Fixes #11